### PR TITLE
Add test setup file requirement in test files

### DIFF
--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -1,7 +1,7 @@
+require './test/setup'
 require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/enigma'
-require 'mocha/minitest'
 
 class EnigmaTest < Minitest::Test
   def setup

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -1,3 +1,4 @@
+require './test/setup'
 require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/key'

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -3,3 +3,4 @@ SimpleCov.start
 
 require 'minitest/autorun'
 require 'minitest/pride'
+require 'mocha/minitest'


### PR DESCRIPTION
`require 'test/setup.rb'` was previously missing from test files ¯\_(ツ)_/¯
this PR has that requirement added at the top of my test files