### PR TITLE
Refactor: Engima inherits from Cipher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage
+.DS_Store

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -12,4 +12,43 @@ class Cipher
   def format_date
     @today.strftime("%d%m") + @today.strftime("%Y")[2..3]
   end
+
+  def generate_key_hash(key)
+    {A: key.slice(0..1).to_i,
+      B: key.slice(1..2).to_i,
+      C: key.slice(2..3).to_i,
+      D: key.slice(3..4).to_i}
+  end
+
+  def generate_offset_hash(date)
+    sqrd_date = date.to_i ** 2
+    offset = sqrd_date.to_s.slice(-4..-1)
+    {A: offset[0].to_i,
+      B: offset[1].to_i,
+      C: offset[2].to_i,
+      D: offset[3].to_i}
+  end
+
+  def generate_shift_hash(key_hash, offset_hash)
+    {A: key_hash[:A] + offset_hash[:A],
+      B: key_hash[:B] + offset_hash[:B],
+      C: key_hash[:C] + offset_hash[:C],
+      D: key_hash[:D] + offset_hash[:D]}
+  end
+
+  def shift_alphabet(shift)
+    i = 0
+    @alphabet.reduce({}) do |shifted_alphabet, char|
+      shifted_alphabet[char] = @alphabet.rotate(shift)[i]
+      i += 1
+      shifted_alphabet
+    end
+  end
+
+  def shifted_alphabets(a_shift, b_shift, c_shift, d_shift)
+    {A: shift_alphabet(a_shift),
+      B: shift_alphabet(b_shift),
+      C: shift_alphabet(c_shift),
+      D: shift_alphabet(d_shift)}
+  end
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -1,8 +1,11 @@
+require 'date'
+
 class Cipher
-  attr_reader :today
+  attr_reader :today, :alphabet
 
   def initialize
     @today = Date.today
-
+    # consider whether it's an issue for the date attribute to be defined by the date on which the enigma instance was initialized - do we need more flexibility?
+    @alphabet = ("a".."z").to_a << " "
   end
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -51,4 +51,23 @@ class Cipher
       C: shift_alphabet(c_shift),
       D: shift_alphabet(d_shift)}
   end
+
+
+  def shift(text_chars, alphabets)
+    text_chars.map.with_index(1) do |char, i|
+      if @alphabet.include?(char)
+        if i % 4 == 1
+          alphabets[:A][char]
+        elsif i % 4 == 2
+          alphabets[:B][char]
+        elsif i % 4 == 3
+          alphabets[:C][char]
+        elsif i % 4 == 0
+          alphabets[:D][char]
+        end
+      else
+        char
+      end
+    end.join
+  end
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -8,4 +8,8 @@ class Cipher
     # consider whether it's an issue for the date attribute to be defined by the date on which the enigma instance was initialized - do we need more flexibility?
     @alphabet = ("a".."z").to_a << " "
   end
+
+  def format_date
+    @today.strftime("%d%m") + @today.strftime("%Y")[2..3]
+  end
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -1,3 +1,8 @@
 class Cipher
+  attr_reader :today
 
+  def initialize
+    @today = Date.today
+
+  end
 end

--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -1,0 +1,3 @@
+class Cipher
+
+end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,10 +2,6 @@ require_relative 'cipher'
 require_relative 'key'
 
 class Enigma < Cipher
-  def format_date
-    @today.strftime("%d%m") + @today.strftime("%Y")[2..3]
-  end
-
   def generate_key_hash(key)
     {A: key.slice(0..1).to_i,
       B: key.slice(1..2).to_i,

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,4 +1,3 @@
-require 'date'
 require_relative 'key'
 
 class Enigma

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,11 +2,9 @@ require 'date'
 require_relative 'key'
 
 class Enigma
-  attr_reader :today, :alphabet
+  attr_reader :alphabet
 
   def initialize
-    @today = Date.today
-    # consider whether it's an issue for the date attribute to be defined by the date on which the enigma instance was initialized - do we need more flexibility?
     @alphabet = ("a".."z").to_a << " "
   end
 

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,45 +2,6 @@ require_relative 'cipher'
 require_relative 'key'
 
 class Enigma < Cipher
-  def generate_key_hash(key)
-    {A: key.slice(0..1).to_i,
-      B: key.slice(1..2).to_i,
-      C: key.slice(2..3).to_i,
-      D: key.slice(3..4).to_i}
-  end
-
-  def generate_offset_hash(date)
-    sqrd_date = date.to_i ** 2
-    offset = sqrd_date.to_s.slice(-4..-1)
-    {A: offset[0].to_i,
-      B: offset[1].to_i,
-      C: offset[2].to_i,
-      D: offset[3].to_i}
-  end
-
-  def generate_shift_hash(key_hash, offset_hash)
-    {A: key_hash[:A] + offset_hash[:A],
-      B: key_hash[:B] + offset_hash[:B],
-      C: key_hash[:C] + offset_hash[:C],
-      D: key_hash[:D] + offset_hash[:D]}
-  end
-
-  def shift_alphabet(shift)
-    i = 0
-    @alphabet.reduce({}) do |shifted_alphabet, char|
-      shifted_alphabet[char] = @alphabet.rotate(shift)[i]
-      i += 1
-      shifted_alphabet
-    end
-  end
-
-  def shifted_alphabets(a_shift, b_shift, c_shift, d_shift)
-    {A: shift_alphabet(a_shift),
-      B: shift_alphabet(b_shift),
-      C: shift_alphabet(c_shift),
-      D: shift_alphabet(d_shift)}
-  end
-
   def encrypt(message, key = Key.generate, date = format_date)
     key_hash = generate_key_hash(key)
     offset_hash = generate_offset_hash(date)

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,8 +2,6 @@ require_relative 'cipher'
 require_relative 'key'
 
 class Enigma < Cipher
-  attr_reader :alphabet
-
   def format_date
     @today.strftime("%d%m") + @today.strftime("%Y")[2..3]
   end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -2,6 +2,8 @@ require_relative 'cipher'
 require_relative 'key'
 
 class Enigma < Cipher
+  # is it necessary to define initialize and call super?
+
   def encrypt(message, key = Key.generate, date = format_date)
     key_hash = generate_key_hash(key)
     offset_hash = generate_offset_hash(date)
@@ -9,21 +11,7 @@ class Enigma < Cipher
     shifted_alphabets = shifted_alphabets(shift_hash[:A],
       shift_hash[:B], shift_hash[:C], shift_hash[:D])
     message_chars = message.downcase.chars
-    encrypted_message = message_chars.map.with_index(1) do |char, i|
-      if @alphabet.include?(char)
-        if i % 4 == 1
-          shifted_alphabets[:A][char]
-        elsif i % 4 == 2
-          shifted_alphabets[:B][char]
-        elsif i % 4 == 3
-          shifted_alphabets[:C][char]
-        elsif i % 4 == 0
-          shifted_alphabets[:D][char]
-        end
-      else
-        char
-      end
-    end.join
+    encrypted_message = shift(message_chars, shifted_alphabets)
     {encryption: encrypted_message, key: key, date: date}
   end
 
@@ -34,21 +22,7 @@ class Enigma < Cipher
     unshifted_alphabets = shifted_alphabets(-(shift_hash[:A]),
       -(shift_hash[:B]), -(shift_hash[:C]), -(shift_hash[:D]))
     ciphertext_chars = ciphertext.downcase.chars
-    decrypted_message = ciphertext_chars.map.with_index(1) do |char, i|
-      if @alphabet.include?(char)
-        if i % 4 == 1
-          unshifted_alphabets[:A][char]
-        elsif i % 4 == 2
-          unshifted_alphabets[:B][char]
-        elsif i % 4 == 3
-          unshifted_alphabets[:C][char]
-        elsif i % 4 == 0
-          unshifted_alphabets[:D][char]
-        end
-      else
-        char
-      end
-    end.join
+    decrypted_message = shift(ciphertext_chars, unshifted_alphabets)
     {decryption: decrypted_message, key: key, date: date}
   end
 end

--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -1,11 +1,8 @@
+require_relative 'cipher'
 require_relative 'key'
 
-class Enigma
+class Enigma < Cipher
   attr_reader :alphabet
-
-  def initialize
-    @alphabet = ("a".."z").to_a << " "
-  end
 
   def format_date
     @today.strftime("%d%m") + @today.strftime("%Y")[2..3]

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -1,0 +1,11 @@
+require './test/setup'
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/cipher'
+
+class CipherTest < Minitest::Test
+  def test_it_exists
+    cipher = Cipher.new
+    assert_instance_of Cipher, cipher
+  end
+end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -16,4 +16,9 @@ class CipherTest < Minitest::Test
     assert_instance_of Date, @cipher.today
   end
 
+  def test_it_has_alphabet_incl_space
+    assert_equal true, @cipher.alphabet.include?(" ")
+    assert_equal 27, @cipher.alphabet.count
+  end
+
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -4,8 +4,16 @@ require 'minitest/pride'
 require './lib/cipher'
 
 class CipherTest < Minitest::Test
-  def test_it_exists
-    cipher = Cipher.new
-    assert_instance_of Cipher, cipher
+  def setup
+    @cipher = Cipher.new
   end
+
+  def test_it_exists
+    assert_instance_of Cipher, @cipher
+  end
+
+  def test_it_has_todays_date
+    assert_instance_of Date, @cipher.today
+  end
+
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -21,4 +21,9 @@ class CipherTest < Minitest::Test
     assert_equal 27, @cipher.alphabet.count
   end
 
+  def test_it_can_format_todays_date
+    assert_instance_of String, @cipher.format_date
+    assert_equal 6, @cipher.format_date.length
+    # consider how to use stub here: Date.stubs(:today).returns()
+  end
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -57,4 +57,14 @@ class CipherTest < Minitest::Test
     assert_equal 4, @cipher.shifted_alphabets(2, 27, 73, 20).keys.count
     # need more robust assertions
   end
+
+  def test_it_can_shift_text_based_on_alphabet_set
+    skip
+    shifted_alphabets = @cipher.shifted_alphabets(2, 27, 73, 20)
+    chars = "keder".chars
+    @cipher.stubs(:generate_shift_hash).returns({A: 3, B: 27, C: 73, D: 20})
+    # @cipher.stubs(:format_date).returns("040895")
+    # Key.stubs(:generate).returns("02715")
+    assert_equal "keder", @cipher.shift(chars, shifted_alphabets)
+  end
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -26,4 +26,35 @@ class CipherTest < Minitest::Test
     assert_equal 6, @cipher.format_date.length
     # consider how to use stub here: Date.stubs(:today).returns()
   end
+
+  def test_it_can_generate_key_hash
+    key = "02715"
+    key_hash = {:A=>2, :B=>27, :C=>71, :D=>15}
+    assert_equal key_hash, @cipher.generate_key_hash(key)
+  end
+
+  def test_it_can_generate_offset_hash
+    date = "040895"
+    offset_hash = {:A=>1, :B=>0, :C=>2, :D=>5}
+    assert_equal offset_hash, @cipher.generate_offset_hash(date)
+  end
+
+  def test_it_can_generate_shift_hash
+    key_hash = {:A=>2, :B=>27, :C=>71, :D=>15}
+    offset_hash = {:A=>1, :B=>0, :C=>2, :D=>5}
+    shift_hash = {A: 3, B: 27, C: 73, D: 20}
+    assert_equal shift_hash, @cipher.generate_shift_hash(key_hash, offset_hash)
+  end
+
+  def test_it_can_create_shifted_alphabet
+    shifted_alphabet = @cipher.shift_alphabet(3)
+    assert_equal ("a".."z").to_a << " ", shifted_alphabet.keys
+    assert_equal ("a".."z").to_a << " ", shifted_alphabet.values.rotate(-3)
+    # better way to test?
+  end
+
+  def test_it_can_create_all_shifted_alphabets
+    assert_equal 4, @cipher.shifted_alphabets(2, 27, 73, 20).keys.count
+    # need more robust assertions
+  end
 end


### PR DESCRIPTION
• Create inheritance relationship from Cipher to Enigma so Enigma now just holds #encrypt and #decrypt methods
• Come back to fix `test_it_can_shift_text_based_on_alphabet_set`
• Consider how to remove nested conditional from `Cipher#shift` and how to separate conditional into another helper method