### PR TITLE
Fix stub error in testing Enigma and Cipher#format_date method

### DIFF
--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -22,10 +22,11 @@ class CipherTest < Minitest::Test
   end
 
   def test_it_can_format_todays_date
-    assert_instance_of String, @cipher.format_date
-    assert_equal 6, @cipher.format_date.length
-    # @cipher.stubs(:today).returns(Date.new(1995, 8, 4))
-    # assert_equal "040895", @cipher.format_date
+    Date.stubs(:today).returns(Date.new(1995, 8, 4))
+    cipher = Cipher.new
+    assert_instance_of String, cipher.format_date
+    assert_equal 6, cipher.format_date.length
+    assert_equal "040895", cipher.format_date
   end
 
   def test_it_can_generate_key_hash

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -22,10 +22,11 @@ class EnigmaTest < Minitest::Test
   end
 
   def test_it_can_format_todays_date
-    assert_instance_of String, @enigma.format_date
-    assert_equal 6, @enigma.format_date.length
-    # @enigma.stubs(:today).returns(Date.new(1995, 8, 4))
-    # assert_equal "040895", @enigma.format_date
+    Date.stubs(:today).returns(Date.new(1995, 8, 4))
+    enigma = Enigma.new
+    assert_instance_of String, enigma.format_date
+    assert_equal 6, enigma.format_date.length
+    assert_equal "040895", enigma.format_date
   end
 
   def test_it_can_generate_key_hash


### PR DESCRIPTION
Created new instance of enigma and cipher in respective tests to override @today attribute created upon initialize in test setups